### PR TITLE
feature: add support for merge patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@js-joda/core": "^5.2.0",
         "@outfoxx/cbor-redux": "^0.3.1",
-        "@outfoxx/jackson-js": "^1.2.22",
+        "@outfoxx/jackson-js": "^1.3.4",
         "common-tags": "^1.8.2",
         "tslib": "^2.4.0",
         "uri-template-lite": "^22.1.0"
@@ -1424,9 +1424,9 @@
       "integrity": "sha512-C7OwetD2nutZVwaS5YYcMh5C0Xmqb/cEEVjjlcd2Pr22suGub7lWlUwiLm/p65QqTX73V+UaW4oPnhW8yej+EA=="
     },
     "node_modules/@outfoxx/jackson-js": {
-      "version": "1.2.22",
-      "resolved": "https://registry.npmjs.org/@outfoxx/jackson-js/-/jackson-js-1.2.22.tgz",
-      "integrity": "sha512-enMvNwYLuufMhXLLTm4yYOjzZbQ22YkdbH8v5jushReydeAb5uCRojg//wB/PP2ulBrXDe8r/dLhsz1NLPmNqw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@outfoxx/jackson-js/-/jackson-js-1.3.4.tgz",
+      "integrity": "sha512-PVBhlUZAnazv+4YRRveH7N/oTuXOPJdgU2y5+SZB71r9iKNkGW7UIKgVggYJ6XOj3xVhKAMqjprm2sAs0rpyqw==",
       "dependencies": {
         "lodash.clone": "^4.5.0",
         "lodash.clonedeep": "^4.5.0",
@@ -8141,9 +8141,9 @@
       "integrity": "sha512-C7OwetD2nutZVwaS5YYcMh5C0Xmqb/cEEVjjlcd2Pr22suGub7lWlUwiLm/p65QqTX73V+UaW4oPnhW8yej+EA=="
     },
     "@outfoxx/jackson-js": {
-      "version": "1.2.22",
-      "resolved": "https://registry.npmjs.org/@outfoxx/jackson-js/-/jackson-js-1.2.22.tgz",
-      "integrity": "sha512-enMvNwYLuufMhXLLTm4yYOjzZbQ22YkdbH8v5jushReydeAb5uCRojg//wB/PP2ulBrXDe8r/dLhsz1NLPmNqw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@outfoxx/jackson-js/-/jackson-js-1.3.4.tgz",
+      "integrity": "sha512-PVBhlUZAnazv+4YRRveH7N/oTuXOPJdgU2y5+SZB71r9iKNkGW7UIKgVggYJ6XOj3xVhKAMqjprm2sAs0rpyqw==",
       "requires": {
         "lodash.clone": "^4.5.0",
         "lodash.clonedeep": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@js-joda/core": "^5.2.0",
     "@outfoxx/cbor-redux": "^0.3.1",
-    "@outfoxx/jackson-js": "^1.2.22",
+    "@outfoxx/jackson-js": "^1.3.4",
     "common-tags": "^1.8.2",
     "tslib": "^2.4.0",
     "uri-template-lite": "^22.1.0"

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -29,8 +29,8 @@ export async function validate(
       response.headers.get('content-type'),
       MediaType.OctetStream,
     );
-    const isProblemJSON = mediaType?.compatible(MediaType.ProblemJSON) ?? false;
-    if (!isProblemJSON) {
+    const isProblem = mediaType?.compatible(MediaType.Problem) ?? false;
+    if (!isProblem) {
       throw await Problem.fromResponse(response);
     }
 

--- a/src/media-type.ts
+++ b/src/media-type.ts
@@ -342,9 +342,21 @@ export namespace MediaType {
     suffix: Suffix.XML,
   });
 
-  export const ProblemJSON = new MediaType({
+  export const Problem = new MediaType({
     type: MediaType.Type.Application,
     subtype: 'problem',
+    suffix: Suffix.JSON,
+  });
+
+  export const JsonPatch = new MediaType({
+    type: MediaType.Type.Application,
+    subtype: 'json-patch',
+    suffix: Suffix.JSON,
+  });
+
+  export const MergePatch = new MediaType({
+    type: MediaType.Type.Application,
+    subtype: 'merge-patch',
     suffix: Suffix.JSON,
   });
 }

--- a/test/fetch-request-factory.test.ts
+++ b/test/fetch-request-factory.test.ts
@@ -361,7 +361,7 @@ describe('FetchRequestFactory', () => {
     fetchMock.getOnce('http://example.com', {
       body: problemJSON,
       status: 400,
-      headers: { 'content-type': MediaType.ProblemJSON.value },
+      headers: { 'content-type': MediaType.Problem.value },
     });
 
     await expectAsync(
@@ -388,7 +388,7 @@ describe('FetchRequestFactory', () => {
     fetchMock.getOnce('http://example.com', {
       body: problemJSON,
       status: 400,
-      headers: { 'content-type': MediaType.ProblemJSON.value },
+      headers: { 'content-type': MediaType.Problem.value },
     });
 
     await expectAsync(

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -83,7 +83,7 @@ describe('Fetch API Utilities', () => {
       new Response(problem, {
         status: 400,
         statusText: 'Bad Request',
-        headers: { 'content-type': MediaType.ProblemJSON.value },
+        headers: { 'content-type': MediaType.Problem.value },
       }),
     );
 

--- a/test/patch.test.ts
+++ b/test/patch.test.ts
@@ -1,0 +1,153 @@
+// Copyright 2020 Outfox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { JSONDecoder, JSONEncoder } from '../src';
+import {
+  JsonClassType,
+  JsonInclude,
+  JsonIncludeType,
+  JsonProperty,
+} from '@outfoxx/jackson-js';
+
+@JsonInclude({ value: JsonIncludeType.ALWAYS })
+class BPatch {
+  @JsonProperty({ required: false })
+  @JsonClassType({ type: () => [String] })
+  public type?: string;
+  @JsonProperty({ required: false })
+  @JsonClassType({ type: () => [ArrayBuffer] })
+  public enc?: ArrayBuffer | null;
+  @JsonProperty({ required: false })
+  @JsonClassType({ type: () => [ArrayBuffer] })
+  public sig?: ArrayBuffer | null;
+
+  constructor(init: Partial<BPatch>) {
+    Object.assign(this, init);
+  }
+}
+
+@JsonInclude({ value: JsonIncludeType.ALWAYS })
+class APatch {
+  @JsonProperty({ required: false })
+  @JsonClassType({ type: () => [String] })
+  public name?: string | null;
+  @JsonProperty({ required: false })
+  @JsonClassType({ type: () => [BPatch] })
+  public b?: BPatch | null;
+  @JsonProperty({ required: false })
+  @JsonClassType({ type: () => [String] })
+  public c?: string | null;
+
+  constructor(init: Partial<APatch>) {
+    Object.assign(this, init);
+  }
+}
+
+describe('JSON Merge Patching', () => {
+  describe('validate JacksonJS functionality', () => {
+    it('handles nested patch classes', () => {
+      const patch = new APatch({
+        name: 'kevin',
+        b: new BPatch({
+          type: '17',
+          enc: new Uint8Array([1, 2, 3]).buffer,
+          sig: null,
+        }),
+      });
+
+      const patchJSON = JSONEncoder.default.encode(patch, [APatch]);
+      const patchDecoded = JSONDecoder.default.decodeText<APatch>(patchJSON, [
+        APatch,
+      ]);
+
+      expect(patchDecoded.c).toBeUndefined();
+      expect(patchDecoded.b?.sig).toBeNull();
+      expect(patchDecoded).toEqual(patch);
+      expect(JSONEncoder.default.encode(patchDecoded)).toEqual(patchJSON);
+    });
+
+    it('excludes undefined primitives', () => {
+      const patch = new APatch({
+        name: 'kevin',
+        b: new BPatch({
+          type: '17',
+          enc: new Uint8Array([1, 2, 3]).buffer,
+          sig: null,
+        }),
+      });
+
+      const patchJSON = JSONEncoder.default.encode(patch, [APatch]);
+      const patchDecoded = JSONDecoder.default.decodeText<APatch>(patchJSON, [
+        APatch,
+      ]);
+
+      expect(patchDecoded.c).toBeUndefined();
+      expect(patchDecoded).toEqual(patch);
+      expect(JSONEncoder.default.encode(patchDecoded)).toEqual(patchJSON);
+    });
+
+    it('excludes undefined classes', () => {
+      const patch = new APatch({
+        name: 'kevin',
+        c: 'test',
+      });
+
+      const patchJSON = JSONEncoder.default.encode(patch, [APatch]);
+      const patchDecoded = JSONDecoder.default.decodeText<APatch>(patchJSON, [
+        APatch,
+      ]);
+
+      expect(patchDecoded.b).toBeUndefined();
+      expect(patchDecoded).toEqual(patch);
+      expect(JSONEncoder.default.encode(patchDecoded)).toEqual(patchJSON);
+    });
+
+    it('includes null primitives', () => {
+      const patch = new APatch({
+        name: 'kevin',
+        b: new BPatch({
+          type: '17',
+          enc: new Uint8Array([1, 2, 3]).buffer,
+          sig: null,
+        }),
+        c: null,
+      });
+
+      const patchJSON = JSONEncoder.default.encode(patch, [APatch]);
+      const patchDecoded = JSONDecoder.default.decodeText<APatch>(patchJSON, [
+        APatch,
+      ]);
+
+      expect(patchDecoded.c).toBeNull();
+      expect(patchDecoded).toEqual(patch);
+      expect(JSONEncoder.default.encode(patchDecoded)).toEqual(patchJSON);
+    });
+
+    it('includes null classes', () => {
+      const patch = new APatch({
+        name: 'kevin',
+        b: null,
+        c: 'test',
+      });
+
+      const patchJSON = JSONEncoder.default.encode(patch, [APatch]);
+      const patchDecoded = JSONDecoder.default.decodeText<APatch>(patchJSON, [
+        APatch,
+      ]);
+
+      expect(patchDecoded.b).toBeNull();
+      expect(JSONEncoder.default.encode(patchDecoded)).toEqual(patchJSON);
+    });
+  });
+});

--- a/test/rxjs.test.ts
+++ b/test/rxjs.test.ts
@@ -57,7 +57,7 @@ describe('RxJS Utils', () => {
     fetchMock.getOnce('http://example.com', {
       throws: Problem.fromStatus(404, 'Not Found'),
       status: 404,
-      headers: { 'content-type': MediaType.ProblemJSON.value },
+      headers: { 'content-type': MediaType.Problem.value },
     });
 
     const fetchRequestFactory = new FetchRequestFactory('http://example.com');
@@ -75,7 +75,7 @@ describe('RxJS Utils', () => {
     fetchMock.getOnce('http://example.com', {
       throws: new TestProblem(),
       status: 404,
-      headers: { 'content-type': MediaType.ProblemJSON.value },
+      headers: { 'content-type': MediaType.Problem.value },
     });
 
     const fetchRequestFactory = new FetchRequestFactory('http://example.com');


### PR DESCRIPTION
* This only tests sample “generated” patch classes because there is no required support classes
* jackson-js compatibility is required; it is updated to a minimum supporting version