### PR TITLE
Skip undecodable SSE events

### DIFF
--- a/src/fetch-request-factory.ts
+++ b/src/fetch-request-factory.ts
@@ -344,7 +344,11 @@ export class FetchRequestFactory implements RequestFactory {
         push(decodedEvent);
       }
       catch (err) {
-        fail(err);
+        this.logger?.warn?.('skipping undecodable event stream event', {
+          error: err,
+          event: event.type,
+          id: event.lastEventId,
+        });
       }
     };
 

--- a/src/fetch-request-factory.ts
+++ b/src/fetch-request-factory.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { ZodError } from 'zod';
 import { SchemaLike } from './schema-runtime.js';
 import { mergeHeaders, validate } from './fetch.js';
 import { FetchEventSource } from './fetch-event-source.js';
@@ -344,6 +345,11 @@ export class FetchRequestFactory implements RequestFactory {
         push(decodedEvent);
       }
       catch (err) {
+        if (!isEventDecodingError(err)) {
+          fail(err);
+          return;
+        }
+
         this.logger?.warn?.('skipping undecodable event stream event', {
           error: err,
           event: event.type,
@@ -423,6 +429,10 @@ export class FetchRequestFactory implements RequestFactory {
       },
     };
   }
+}
+
+function isEventDecodingError(error: unknown): error is SyntaxError | ZodError {
+  return error instanceof SyntaxError || error instanceof ZodError;
 }
 
 function composeAbortSignals(

--- a/test/fetch-request-factory.test.ts
+++ b/test/fetch-request-factory.test.ts
@@ -41,6 +41,10 @@ const TestSchema = z.object({
   sub: SubSchema,
 });
 
+const EventSchema = z.object({
+  target: z.string(),
+});
+
 const TestArraySchema = z.array(TestSchema);
 
 const TestSetSchema = z.codec(
@@ -388,6 +392,51 @@ describe('FetchRequestFactory', () => {
                                 target: 'world',
                               }),
     );
+  });
+
+  it('skips undecodable eventStream events and continues consuming', async () => {
+    const encodedEvents = new TextEncoder().encode(
+      [
+        'event: hello\nid: bad\ndata: {"target":5}\n\n',
+        'event: hello\nid: good\ndata: {"target":"world"}\n\n',
+      ].join(''),
+    ).buffer;
+
+    fetchMock.getOnce(
+      'http://example.com',
+      () =>
+        new Response(new Blob([encodedEvents]), {
+          headers: { 'content-type': MediaType.EventStream.toString() },
+        }),
+    );
+    fetchMock.getOnce(
+      'http://example.com',
+      () => new Promise((resolve) => setTimeout(resolve, 5000)),
+    );
+
+    const warnings: unknown[][] = [];
+    const fetchRequestFactory = new FetchRequestFactory('http://example.com', {
+      logger: {
+        warn: (...data) => warnings.push(data),
+      },
+    });
+
+    const eventStream = fetchRequestFactory.eventStream(
+      { method: 'GET', pathTemplate: '' },
+      (decoder, _event, _id, data) => decoder.decodeText(data, EventSchema),
+    );
+
+    const iterator = eventStream[Symbol.asyncIterator]();
+    const { value } = await iterator.next();
+    await iterator.return?.();
+
+    expect(value).toEqual(
+      expect.objectContaining({
+                                target: 'world',
+                              }),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0][0]).toBe('skipping undecodable event stream event');
   });
 
   it('aborts response with an AbortSignal', async () => {

--- a/test/fetch-request-factory.test.ts
+++ b/test/fetch-request-factory.test.ts
@@ -432,11 +432,41 @@ describe('FetchRequestFactory', () => {
 
     expect(value).toEqual(
       expect.objectContaining({
-                                target: 'world',
-                              }),
+        target: 'world',
+      }),
     );
     expect(warnings).toHaveLength(1);
     expect(warnings[0][0]).toBe('skipping undecodable event stream event');
+  });
+
+  it('fails eventStream when decoder callbacks throw non-decoding errors', async () => {
+    const encodedEvent = new TextEncoder().encode(
+      'event: hello\nid: 12345\ndata: {"target":"world"}\n\n',
+    ).buffer;
+
+    fetchMock.getOnce(
+      'http://example.com',
+      () =>
+        new Response(new Blob([encodedEvent]), {
+          headers: { 'content-type': MediaType.EventStream.toString() },
+        }),
+    );
+
+    const fetchRequestFactory = new FetchRequestFactory('http://example.com', {
+      logger: {},
+    });
+
+    const eventStream = fetchRequestFactory.eventStream(
+      { method: 'GET', pathTemplate: '' },
+      () => {
+        throw new TypeError('decoder callback failed');
+      },
+    );
+
+    const iterator = eventStream[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toThrow('decoder callback failed');
+    await iterator.return?.();
   });
 
   it('aborts response with an AbortSignal', async () => {


### PR DESCRIPTION
## Summary

Update `FetchRequestFactory.eventStream` so a decoder failure logs a warning and skips that SSE event instead of failing the async iterator.

## Root Cause

The JS runtime mirrored the Kotlin failure mode: decoder exceptions inside `eventStream` were routed to the stream failure path, stopping long-lived consumers when they encountered an unmodeled or malformed event.

## Validation

- `bun test -r ./test/setup.ts test/fetch-request-factory.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
