### PR TITLE
Add TypeScript streaming upload operations

### DIFF
--- a/src/fetch-transport.ts
+++ b/src/fetch-transport.ts
@@ -32,6 +32,7 @@ import {
 } from './transport.js';
 import { OperationResponse } from './operation-response.js';
 import { SundayError } from './sunday-error.js';
+import { isStreamingBody } from './streaming-body.js';
 import { URLTemplate } from './url-template.js';
 import { errorToMessage } from './util/errors.js';
 
@@ -110,36 +111,47 @@ export class FetchTransport implements Transport {
     }
 
     // Determine content type
+    const streamingBody = isStreamingBody(requestSpec.body)
+      ? requestSpec.body
+      : undefined;
     const contentType = requestSpec.contentTypes?.find((type) =>
-                                                         this.mediaTypeEncoders.supports(type),
+      streamingBody !== undefined || this.mediaTypeEncoders.supports(type),
     );
 
     // If matched, add the content type (even if the body is nil,
     // to match any expected server requirements)
-    if (contentType) {
+    if (contentType && !headers.has('content-type')) {
       headers.set('content-type', contentType.toString());
     }
 
     // Encode & add body data
     let body: BodyInit | undefined;
-    if (requestSpec.body) {
-      if (!contentType) {
-        throw new Error(
-          'None of the provided content types has a registered encoder',
-        );
+    if (requestSpec.body !== undefined) {
+      if (streamingBody !== undefined) {
+        body = streamingBody.toBodyInit();
       }
+      else {
+        if (!contentType) {
+          throw new Error(
+            'None of the provided content types has a registered encoder',
+          );
+        }
 
-      body = this.mediaTypeEncoders
-                 .find(contentType)
-                 .encode(requestSpec.body, requestSpec.bodyType);
+        body = this.mediaTypeEncoders
+                   .find(contentType)
+                   .encode(requestSpec.body, requestSpec.bodyType);
+      }
     }
 
-    const init: RequestInit = {
+    const init: RequestInit & { duplex?: 'half' } = {
       headers,
       body,
       method: requestSpec.method,
       signal: requestSpec.signal,
     };
+    if (body instanceof ReadableStream) {
+      init.duplex = 'half';
+    }
 
     const request = new Request(url.toString(), init);
     return (await this.adapter?.adapt(this, request)) ?? request;

--- a/src/fetch-transport.ts
+++ b/src/fetch-transport.ts
@@ -120,7 +120,7 @@ export class FetchTransport implements Transport {
 
     // If matched, add the content type (even if the body is nil,
     // to match any expected server requirements)
-    if (contentType && !headers.has('content-type')) {
+    if (contentType && (streamingBody === undefined || !headers.has('content-type'))) {
       headers.set('content-type', contentType.toString());
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export * from './logger.js';
 export * from './sunday-error.js';
 export * from './problem.js';
 export * from './date-time-types.js';
+export * from './streaming-body.js';
 export * from './operation-response.js';
 export * from './operation.js';
 export * from './request-adapters.js';

--- a/src/operation.ts
+++ b/src/operation.ts
@@ -15,6 +15,7 @@
 import { Transport, RequestSpec } from './transport.js';
 import { OperationResponse } from './operation-response.js';
 import { SchemaLike } from './schema-runtime.js';
+import { StreamingBody } from './streaming-body.js';
 import { nullifyProblem, type ProblemMatcher } from './util/nullify.js';
 
 /** Extracts the native request type from a transport. */
@@ -70,6 +71,13 @@ export interface Operation<
   transportResponse(options?: ExecuteOptions): Promise<Response>;
 }
 
+/** A generated streaming upload operation. */
+export interface StreamingOperation<
+  ResponseBody,
+  Factory extends Transport<unknown> = Transport,
+> extends Operation<StreamingBody, ResponseBody, Factory> {
+}
+
 /** A generated operation that can execute select problems as null responses. */
 export interface NullableOperation<
   RequestBody,
@@ -99,6 +107,25 @@ export function createOperation<RequestBody, ResponseBody, Factory extends Trans
   transport: Factory,
   spec: OperationSpec<RequestBody, ResponseBody>,
 ): Operation<RequestBody, ResponseBody, Factory> {
+  return new TransportOperation(transport, spec);
+}
+
+/** Creates a streaming upload operation with a decoded response body. */
+export function createStreamingOperation<ResponseBody = void, Factory extends Transport<unknown> = Transport>(
+  transport: Factory,
+  spec: TypedOperationSpec<StreamingBody, ResponseBody>,
+): StreamingOperation<ResponseBody, Factory>;
+
+/** Creates a streaming upload operation with no decoded response body. */
+export function createStreamingOperation<Factory extends Transport<unknown> = Transport>(
+  transport: Factory,
+  spec: VoidOperationSpec<StreamingBody>,
+): StreamingOperation<void, Factory>;
+
+export function createStreamingOperation<ResponseBody, Factory extends Transport<unknown>>(
+  transport: Factory,
+  spec: OperationSpec<StreamingBody, ResponseBody>,
+): StreamingOperation<ResponseBody, Factory> {
   return new TransportOperation(transport, spec);
 }
 

--- a/src/streaming-body.ts
+++ b/src/streaming-body.ts
@@ -1,0 +1,84 @@
+// Copyright 2020 Outfox, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Binary chunk values supported by streaming request bodies. */
+export type StreamingBodyChunk = ArrayBuffer | Uint8Array;
+
+/** Creates a fresh async byte sequence for a streaming request body. */
+export type StreamingBodyBytesFactory = () => AsyncIterable<StreamingBodyChunk>;
+
+/** Creates a fresh web readable stream for a streaming request body. */
+export type StreamingBodyStreamFactory = () => ReadableStream<Uint8Array>;
+
+/** A lazily-created request body for streaming uploads. */
+export class StreamingBody {
+  private constructor(
+    private readonly createBody: () => BodyInit,
+  ) {
+  }
+
+  /** Creates a streaming body from a reusable web platform `Blob`. */
+  static blob(blob: Blob): StreamingBody {
+    return new StreamingBody(() => blob);
+  }
+
+  /** Creates a streaming body from a fresh web `ReadableStream` factory. */
+  static stream(factory: StreamingBodyStreamFactory): StreamingBody {
+    return new StreamingBody(factory);
+  }
+
+  /** Creates a streaming body from a fresh async byte iterable factory. */
+  static bytes(factory: StreamingBodyBytesFactory): StreamingBody {
+    return new StreamingBody(() => asyncBytesToReadableStream(factory()));
+  }
+
+  /** Creates the web platform body value consumed by `fetch`. */
+  toBodyInit(): BodyInit {
+    return this.createBody();
+  }
+}
+
+/** Returns true when a value is a Sunday streaming request body. */
+export function isStreamingBody(value: unknown): value is StreamingBody {
+  return value instanceof StreamingBody;
+}
+
+function asyncBytesToReadableStream(
+  bytes: AsyncIterable<StreamingBodyChunk>,
+): ReadableStream<Uint8Array> {
+  const iterator = bytes[Symbol.asyncIterator]();
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller): Promise<void> {
+      try {
+        const next = await iterator.next();
+        if (next.done === true) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(toUint8Array(next.value));
+      }
+      catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel(reason): Promise<void> {
+      await iterator.return?.(reason);
+    },
+  });
+}
+
+function toUint8Array(chunk: StreamingBodyChunk): Uint8Array {
+  return chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+}

--- a/test/fetch-transport.test.ts
+++ b/test/fetch-transport.test.ts
@@ -196,6 +196,20 @@ describe('FetchTransport', () => {
     expect(request.headers.get('Content-Type')).toBe(MediaType.JSON.value);
   });
 
+  it('uses encoded content-type over explicit non-streaming body headers', async () => {
+    const request: Request = await fetchTransport.transportRequest({
+                                                                 method: 'POST',
+                                                                 pathTemplate: '/api/contents',
+                                                                 body: { a: 5 },
+                                                                 bodyType: UnknownSchema,
+                                                                 contentTypes: [MediaType.JSON],
+                                                                 headers: { 'Content-Type': 'text/plain' },
+                                                               });
+
+    expect(await request.text()).toBe('{"a":5}');
+    expect(request.headers.get('Content-Type')).toBe(MediaType.JSON.value);
+  });
+
   it('attaches streaming byte bodies lazily', async () => {
     let calls = 0;
     const body = StreamingBody.bytes(async function* () {
@@ -235,6 +249,39 @@ describe('FetchTransport', () => {
     });
 
     expect(await request.text()).toBe('blob-data');
+  });
+
+  it('attaches streaming stream bodies with fresh streams', async () => {
+    let calls = 0;
+    const body = StreamingBody.stream(() => {
+      calls += 1;
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(`stream-${calls}`));
+          controller.close();
+        },
+      });
+    });
+
+    expect(calls).toBe(0);
+
+    const firstRequest = await fetchTransport.transportRequest({
+      method: 'POST',
+      pathTemplate: '/api/archive',
+      body,
+      contentTypes: [MediaType.OctetStream],
+    });
+    expect(await firstRequest.text()).toBe('stream-1');
+    expect(calls).toBe(1);
+
+    const secondRequest = await fetchTransport.transportRequest({
+      method: 'POST',
+      pathTemplate: '/api/archive',
+      body,
+      contentTypes: [MediaType.OctetStream],
+    });
+    expect(await secondRequest.text()).toBe('stream-2');
+    expect(calls).toBe(2);
   });
 
   it('preserves explicit streaming content-type headers', async () => {

--- a/test/fetch-transport.test.ts
+++ b/test/fetch-transport.test.ts
@@ -25,6 +25,7 @@ import {
   ProblemWireSchema,
   defineSchema,
   SchemaLike,
+  StreamingBody,
   SundayError,
 } from '../src';
 import { unknownGet } from '../src/util/unknowns';
@@ -193,6 +194,59 @@ describe('FetchTransport', () => {
     expect(request.url).toBe('http://example.com/api/contents');
     expect(request.text()).resolves.toBe('{"a":5}');
     expect(request.headers.get('Content-Type')).toBe(MediaType.JSON.value);
+  });
+
+  it('attaches streaming byte bodies lazily', async () => {
+    let calls = 0;
+    const body = StreamingBody.bytes(async function* () {
+      calls += 1;
+      yield new TextEncoder().encode('hello ');
+      yield new TextEncoder().encode('world');
+    });
+
+    expect(calls).toBe(0);
+
+    const firstRequest = await fetchTransport.transportRequest({
+      method: 'POST',
+      pathTemplate: '/api/archive',
+      body,
+      contentTypes: [MediaType.OctetStream],
+    });
+    expect(firstRequest.headers.get('Content-Type')).toBe(MediaType.OctetStream.value);
+    expect(await firstRequest.text()).toBe('hello world');
+    expect(calls).toBe(1);
+
+    const secondRequest = await fetchTransport.transportRequest({
+      method: 'POST',
+      pathTemplate: '/api/archive',
+      body,
+      contentTypes: [MediaType.OctetStream],
+    });
+    expect(await secondRequest.text()).toBe('hello world');
+    expect(calls).toBe(2);
+  });
+
+  it('attaches streaming blob bodies', async () => {
+    const request = await fetchTransport.transportRequest({
+      method: 'POST',
+      pathTemplate: '/api/archive',
+      body: StreamingBody.blob(new Blob(['blob-data'])),
+      contentTypes: [MediaType.OctetStream],
+    });
+
+    expect(await request.text()).toBe('blob-data');
+  });
+
+  it('preserves explicit streaming content-type headers', async () => {
+    const request = await fetchTransport.transportRequest({
+      method: 'POST',
+      pathTemplate: '/api/archive',
+      body: StreamingBody.blob(new Blob(['image'])),
+      contentTypes: [MediaType.OctetStream],
+      headers: { 'Content-Type': 'image/png' },
+    });
+
+    expect(request.headers.get('Content-Type')).toBe('image/png');
   });
 
   it('sets content-type when body is non-existent', async () => {

--- a/test/operation.test.ts
+++ b/test/operation.test.ts
@@ -21,10 +21,12 @@ import {
   Transport,
   RequestSpec,
   SchemaLike,
+  StreamingBody,
   TextMediaTypeDecoder,
   URLTemplate,
   createOperation,
   createNullableOperation,
+  createStreamingOperation,
 } from '../src';
 import { OperationResponse } from '../src/operation-response';
 
@@ -120,6 +122,26 @@ describe('Operation', () => {
     const operation = createOperation(transport, spec);
 
     expect(operation.spec).toBe(spec);
+  });
+
+  it('creates streaming operations over streaming request bodies', async () => {
+    const transport = new TestTransport({ id: '123' });
+    const body = StreamingBody.bytes(async function* () {
+      yield new TextEncoder().encode('body');
+    });
+    const operation = createStreamingOperation(transport, {
+      request: { method: 'PUT', pathTemplate: '/archive', body },
+      responseType: TestSchema,
+    });
+
+    await expect(operation.execute()).resolves.toEqual({ id: '123' });
+
+    expect(transport.resultCalls).toEqual([
+      {
+        request: { method: 'PUT', pathTemplate: '/archive', body },
+        resultType: TestSchema,
+      },
+    ]);
   });
 
   it('executes nullable operations normally when no matching problem is thrown', async () => {

--- a/tools/stub/index.ts
+++ b/tools/stub/index.ts
@@ -2,7 +2,7 @@ import { MediaType } from '../../src/media-type.js';
 import { nullifyProblem } from '../../src/util/nullify.js';
 import { Problem, ProblemWireSchema, createProblemCodec } from '../../src/problem.js';
 import { defineSchema } from '../../src/schema-runtime.js';
-import { StreamingBody } from '../../src/streaming-body.js';
+import { StreamingBody, isStreamingBody } from '../../src/streaming-body.js';
 import { Transport } from '../../src/transport.js';
 import {
   createNullableOperation,
@@ -65,6 +65,7 @@ export {
   createProblemCodec,
   defineSchema,
   StreamingBody,
+  isStreamingBody,
   Transport,
   createNullableOperation,
   createOperation,

--- a/tools/stub/index.ts
+++ b/tools/stub/index.ts
@@ -2,12 +2,15 @@ import { MediaType } from '../../src/media-type.js';
 import { nullifyProblem } from '../../src/util/nullify.js';
 import { Problem, ProblemWireSchema, createProblemCodec } from '../../src/problem.js';
 import { defineSchema } from '../../src/schema-runtime.js';
+import { StreamingBody } from '../../src/streaming-body.js';
 import { Transport } from '../../src/transport.js';
 import {
   createNullableOperation,
   createOperation,
+  createStreamingOperation,
   NullableOperation,
   Operation,
+  StreamingOperation,
   TransportRequest,
 } from '../../src/operation.js';
 import {
@@ -61,11 +64,14 @@ export {
   ProblemWireSchema,
   createProblemCodec,
   defineSchema,
+  StreamingBody,
   Transport,
   createNullableOperation,
   createOperation,
+  createStreamingOperation,
   NullableOperation,
   Operation,
+  StreamingOperation,
   TransportRequest,
   OperationResponse,
   ResponseHeaderEntry,

--- a/tools/stub/out/index.d.ts
+++ b/tools/stub/out/index.d.ts
@@ -206,6 +206,8 @@ export declare class StreamingBody {
 	/** Creates the web platform body value consumed by `fetch`. */
 	toBodyInit(): BodyInit;
 }
+/** Returns true when a value is a Sunday streaming request body. */
+export declare function isStreamingBody(value: unknown): value is StreamingBody;
 export interface MediaTypeDecoder {
 	decode<T>(response: Response, type: SchemaLike<T>): Promise<T>;
 }

--- a/tools/stub/out/index.d.ts
+++ b/tools/stub/out/index.d.ts
@@ -187,6 +187,25 @@ export declare class Problem extends Error implements Problem {
 export declare function createProblemCodec<TProblem extends Problem, TWire extends z.infer<typeof ProblemWireSchema>>(problemType: new (spec: TWire) => TProblem, wireSchema: z.ZodType<TWire>): z.ZodType<TProblem>;
 export type ProblemMatcher = z.ZodType<Problem> | ((problem: Problem) => boolean);
 export declare function nullifyProblem<T>(promise: Promise<T>, statuses: number[], problemTypes: ProblemMatcher[]): Promise<T | null>;
+/** Binary chunk values supported by streaming request bodies. */
+export type StreamingBodyChunk = ArrayBuffer | Uint8Array;
+/** Creates a fresh async byte sequence for a streaming request body. */
+export type StreamingBodyBytesFactory = () => AsyncIterable<StreamingBodyChunk>;
+/** Creates a fresh web readable stream for a streaming request body. */
+export type StreamingBodyStreamFactory = () => ReadableStream<Uint8Array>;
+/** A lazily-created request body for streaming uploads. */
+export declare class StreamingBody {
+	private readonly createBody;
+	private constructor();
+	/** Creates a streaming body from a reusable web platform `Blob`. */
+	static blob(blob: Blob): StreamingBody;
+	/** Creates a streaming body from a fresh web `ReadableStream` factory. */
+	static stream(factory: StreamingBodyStreamFactory): StreamingBody;
+	/** Creates a streaming body from a fresh async byte iterable factory. */
+	static bytes(factory: StreamingBodyBytesFactory): StreamingBody;
+	/** Creates the web platform body value consumed by `fetch`. */
+	toBodyInit(): BodyInit;
+}
 export interface MediaTypeDecoder {
 	decode<T>(response: Response, type: SchemaLike<T>): Promise<T>;
 }
@@ -304,6 +323,9 @@ export interface Operation<RequestBody, ResponseBody, Factory extends Transport<
 	transportRequest(options?: BuildRequestOptions): Promise<TransportRequest<Factory>>;
 	transportResponse(options?: ExecuteOptions): Promise<Response>;
 }
+/** A generated streaming upload operation. */
+export interface StreamingOperation<ResponseBody, Factory extends Transport<unknown> = Transport> extends Operation<StreamingBody, ResponseBody, Factory> {
+}
 /** A generated operation that can execute select problems as null responses. */
 export interface NullableOperation<RequestBody, ResponseBody, Factory extends Transport<unknown> = Transport> extends Operation<RequestBody, ResponseBody, Factory> {
 	readonly nullify: NullifySpec;
@@ -314,6 +336,10 @@ export interface NullableOperation<RequestBody, ResponseBody, Factory extends Tr
 export declare function createOperation<RequestBody = void, ResponseBody = void, Factory extends Transport<unknown> = Transport>(transport: Factory, spec: TypedOperationSpec<RequestBody, ResponseBody>): Operation<RequestBody, ResponseBody, Factory>;
 /** Creates an operation with no decoded response body. */
 export declare function createOperation<RequestBody = void, Factory extends Transport<unknown> = Transport>(transport: Factory, spec: VoidOperationSpec<RequestBody>): Operation<RequestBody, void, Factory>;
+/** Creates a streaming upload operation with a decoded response body. */
+export declare function createStreamingOperation<ResponseBody = void, Factory extends Transport<unknown> = Transport>(transport: Factory, spec: TypedOperationSpec<StreamingBody, ResponseBody>): StreamingOperation<ResponseBody, Factory>;
+/** Creates a streaming upload operation with no decoded response body. */
+export declare function createStreamingOperation<Factory extends Transport<unknown> = Transport>(transport: Factory, spec: VoidOperationSpec<StreamingBody>): StreamingOperation<void, Factory>;
 /** Creates a nullable operation with a decoded response body. */
 export declare function createNullableOperation<RequestBody = void, ResponseBody = void, Factory extends Transport<unknown> = Transport>(transport: Factory, spec: TypedOperationSpec<RequestBody, ResponseBody>, nullify: NullifySpec): NullableOperation<RequestBody, ResponseBody, Factory>;
 /** Creates a nullable operation with no decoded response body. */


### PR DESCRIPTION
## Summary
- Add a Web Platform-only StreamingBody runtime type for reusable streaming upload bodies
- Add StreamingOperation and createStreamingOperation helpers
- Teach fetch transport to send StreamingBody via Blob, ReadableStream, or async byte factories

## Details
- Uses only Web Platform primitives: Blob, ReadableStream, ArrayBuffer, and Uint8Array
- Adds duplex: half when the body is a ReadableStream
- Preserves explicit Content-Type headers and otherwise derives Content-Type from operation content types

## Validation
- bun run typecheck
- bun test -r ./test/setup.ts test/operation.test.ts test/fetch-transport.test.ts
- bun run check